### PR TITLE
DrillのCRUD機能の追加（livewire）

### DIFF
--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -70,6 +70,24 @@ class DrillIndex extends Component
         $this->closeDrillModal();
     }
 
+    public function drillUpdate()
+    {
+        $drill = Drill::findOrFail($this->editingDrillId);
+
+        $drill->update([
+            'question' => $this->question,
+            'choice_1' => $this->choice_1,
+            'choice_2' => $this->choice_2,
+            'choice_3' => $this->choice_3,
+            'choice_4' => $this->choice_4,
+            'correct_choice' => $this->correct_choice,
+            'explanations' => $this->explanations,
+        ]);
+
+        $this->closeDrillModal();
+        $this->getDrills();
+    }
+
     public function getDrills()
     {
         $this->drills = Drill::where('lesson_id', $this->lesson_id)->get();

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -12,6 +12,7 @@ class DrillIndex extends Component
     public $user_id;
     public $drills;
     public $lessonTitle;
+    public $drillModal = false;
     public $lesson_id, $editingDrillId, $question, $choice_1, $choice_2, $choice_3, $choice_4, $correct_choice, $explanations;
 
     public function mount($lesson_id)
@@ -21,6 +22,17 @@ class DrillIndex extends Component
 
         $this->getDrills();
         $this->getLessonTitle();
+    }
+
+    public function openDrillModal()
+    {
+        $this->drillModal = true;
+    }
+
+    public function closeDrillModal()
+    {
+        $this->drillModal = false;
+        $this->resetDrillForm();
     }
 
     public function getDrills()

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -10,11 +10,9 @@ use Livewire\Component;
 class DrillIndex extends Component
 {
     public $user_id;
-    public $lesson_id;
     public $drills;
     public $lessonTitle;
-
-
+    public $lesson_id, $editingDrillId, $question, $choice_1, $choice_2, $choice_3, $choice_4, $correct_choice, $explanations;
 
     public function mount($lesson_id)
     {
@@ -33,6 +31,11 @@ class DrillIndex extends Component
     public function getLessonTitle()
     {
         $this->lessonTitle = Lesson::where('id', $this->lesson_id)->first()?->title;
+    }
+
+    public function resetDrillForm()
+    {
+        $this->reset(['editingDrillId', 'question', 'choice_1', 'choice_2', 'choice_3', 'choice_4', 'correct_choice', 'explanations']);
     }
 
     public function render()

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -84,8 +84,17 @@ class DrillIndex extends Component
             'explanations' => $this->explanations,
         ]);
 
-        $this->closeDrillModal();
         $this->getDrills();
+        $this->closeDrillModal();
+    }
+
+    public function drillDestroy()
+    {
+        $drill = Drill::findOrFail($this->editingDrillId);
+        $drill->delete();
+
+        $this->getDrills();
+        $this->closeDrillModal();
     }
 
     public function getDrills()

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Drill;
+use App\Models\Lesson;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class DrillIndex extends Component
+{
+    public $user_id;
+    public $lesson_id;
+    public $drills;
+    public $lessonTitle;
+
+
+
+    public function mount($lesson_id)
+    {
+        $this->user_id = Auth::id();
+        $this->lesson_id = $lesson_id;
+
+        $this->getDrills();
+        $this->getLessonTitle();
+    }
+
+    public function getDrills()
+    {
+        $this->drills = Drill::where('lesson_id', $this->lesson_id)->get();
+    }
+
+    public function getLessonTitle()
+    {
+        $this->lessonTitle = Lesson::where('id', $this->lesson_id)->first()?->title;
+    }
+
+    public function render()
+    {
+        return view('livewire.drill-index');
+    }
+}

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -35,6 +35,26 @@ class DrillIndex extends Component
         $this->resetDrillForm();
     }
 
+    public function drillStore()
+    {
+        Drill::create([
+            'user_id' => $this->user_id,
+            'lesson_id' => $this->lesson_id,
+            'question' => $this->question,
+            'choice_1' => $this->choice_1,
+            'choice_2' => $this->choice_2,
+            'choice_3' => $this->choice_3,
+            'choice_4' => $this->choice_4,
+            'correct_choice' => $this->correct_choice,
+            'explanations' => $this->explanations,
+
+        ]);
+
+        $this->getDrills();
+        $this->closeDrillModal();
+    }
+
+
     public function getDrills()
     {
         $this->drills = Drill::where('lesson_id', $this->lesson_id)->get();

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -29,6 +29,22 @@ class DrillIndex extends Component
         $this->drillModal = true;
     }
 
+    public function openEditDrillModal($editingDrillId)
+    {
+        $drill = Drill::findOrFail($editingDrillId);
+
+        $this->editingDrillId = $editingDrillId;
+        $this->question = $drill->question;
+        $this->choice_1 = $drill->choice_1;
+        $this->choice_2 = $drill->choice_2;
+        $this->choice_3 = $drill->choice_3;
+        $this->choice_4 = $drill->choice_4;
+        $this->correct_choice = $drill->correct_choice;
+        $this->explanations = $drill->explanations;
+
+        $this->drillModal = true;
+    }
+
     public function closeDrillModal()
     {
         $this->drillModal = false;
@@ -53,7 +69,6 @@ class DrillIndex extends Component
         $this->getDrills();
         $this->closeDrillModal();
     }
-
 
     public function getDrills()
     {

--- a/resources/views/components/form/livewire-form-container.blade.php
+++ b/resources/views/components/form/livewire-form-container.blade.php
@@ -7,7 +7,7 @@
 ])
 
 <form wire:submit.prevent="{{ $submitWire }}"
-    {{ $attributes->merge(['class' => 'w-full max-w-[480px] mx-auto m-6 p-6 border rounded border-gray-300 bg-white']) }}>
+    {{ $attributes->merge(['class' => 'w-full mx-auto p-6 border rounded border-gray-300 bg-white']) }}>
     @if ($title) <p class="text-center mt-2 mb-6 pb-2 text-xl sm:text-2xl font-semibold border-b text-gray-500 border-gray-300">{{ $title }}</p>@endif
     {{ $slot }}
     <div class="mb-2 text-center">

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -7,7 +7,8 @@
 
 <div class="flex flex-col my-2">
     <label for="{{ $name }}" class="leading-7 text-sm text-gray-600">{{ $slot }}</label>
-    <select id="{{ $name }}" name="{{ $name }}" class="{{ $maxWidth }} border rounded border-gray-300 bg-gray-50 focus:bg-white transition-colors duration-200 ease-in-out">
+    <select id="{{ $name }}" name="{{ $name }}" wire:model="{{ $name }}"
+        class="{{ $maxWidth }} border rounded border-gray-300 bg-gray-50 focus:bg-white transition-colors duration-200 ease-in-out">
         @foreach ($options as $value => $label)
         <option value="{{ $value }}" {{ old($name, $selected) == $value ? 'selected' : '' }}>
             {{ $label }}

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -1,0 +1,17 @@
+@props([
+'name' => null,
+'options' => [],
+'selected' => null,
+'maxWidth' => 'max-w-[120px]',
+])
+
+<div class="flex flex-col my-2">
+    <label for="{{ $name }}" class="leading-7 text-sm text-gray-600">{{ $slot }}</label>
+    <select id="{{ $name }}" name="{{ $name }}" class="{{ $maxWidth }} border rounded border-gray-300 bg-gray-50 focus:bg-white transition-colors duration-200 ease-in-out">
+        @foreach ($options as $value => $label)
+        <option value="{{ $value }}" {{ old($name, $selected) == $value ? 'selected' : '' }}>
+            {{ $label }}
+        </option>
+        @endforeach
+    </select>
+</div>

--- a/resources/views/components/ui/modal-container.blade.php
+++ b/resources/views/components/ui/modal-container.blade.php
@@ -1,4 +1,4 @@
-@props(['maxWidth' => 'max-w-[500px]', 'id' => 'modal', 'wire' => null])
+@props(['maxWidth' => 'max-w-[580px]', 'id' => 'modal', 'wire' => null])
 
 <div id="{{ $id }}"
     @if($wire) wire:click="{{ $wire }}" @endif

--- a/resources/views/components/ui/modal-container.blade.php
+++ b/resources/views/components/ui/modal-container.blade.php
@@ -5,7 +5,7 @@
     class="flex fixed inset-0 items-center justify-center w-full h-full bg-gray-900 bg-opacity-50 z-50">
     <div
         @click.stop
-        {{ $attributes->merge(['class' => "$maxWidth w-full mx-2 p-6 rounded-lg shadow-lg bg-white"]) }}>
+        {{ $attributes->merge(['class' => "$maxWidth w-full max-h-[80%] mx-2 p-6 rounded-lg shadow-lg scroll-y-auto overflow-auto bg-white"]) }}>
         {{ $slot }}
     </div>
 </div>

--- a/resources/views/drills.blade.php
+++ b/resources/views/drills.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            ドリル
+            問題の一覧
         </h2>
     </x-slot>
 
@@ -9,7 +9,7 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
-                    {{ $lesson_id }}
+                    <livewire:drill-index :lesson_id="$lesson_id" />
                 </div>
             </div>
         </div>

--- a/resources/views/drills.blade.php
+++ b/resources/views/drills.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            ドリル
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    {{ $lesson_id }}
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -26,7 +26,7 @@
     <x-ui.modal-container wire="closeDrillModal" id="drill">
         <x-form.livewire-form-container
             title="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}" buttonTitle="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}"
-            submitWire="{{ $editingDrillId ? 'drillUpdate' : 'drillStore' }}" closeWire="closeDrillModal">
+            submitWire="{{ $editingDrillId ? 'drillUpdate' : 'drillStore' }}" closeWire="closeDrillModal" deleteWire="{{ $editingDrillId ? 'drillDestroy' : null }}">
             <x-form.input name="question">問題</x-form.input>
             <x-form.input name="choice_1">解答.1</x-form.input>
             <x-form.input name="choice_2">解答.2</x-form.input>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -23,9 +23,18 @@
     <x-ui.button wire="openDrillModal" class="block mx-auto my-4">モーダルオープン</x-ui.button>
 
     @if($drillModal)
-    <div>
-        モーダルテスト
-        <x-ui.button wire="closeDrillModal" class="block mx-auto my-4">モーダルクローズ</x-ui.button>
-    </div>
+    <x-ui.modal-container wire="closeDrillModal" id="drill">
+        <x-form.livewire-form-container
+            title="ドリルの作成" buttonTitle="作成"
+            closeWire="closeDrillModal">
+            <x-form.input name="question">問題</x-form.input>
+            <x-form.input name="choice_1">解答.1</x-form.input>
+            <x-form.input name="choice_2">解答.2</x-form.input>
+            <x-form.input name="choice_3">解答.3</x-form.input>
+            <x-form.input name="choice_4">解答.4</x-form.input>
+            <x-form.input name="correct_choice">答え</x-form.input>
+            <x-form.textarea name="explanations">解説</x-form.textarea>
+        </x-form.livewire-form-container>
+    </x-ui.modal-container>
     @endif
 </section>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -1,4 +1,4 @@
-<div>
+<section>
     <h2 class="mb-6 text-2xl font-semibold">{{ $lessonTitle }}の詳細</h2>
     <table class="table-auto w-full text-left">
         <thead>
@@ -20,4 +20,12 @@
             @endforeach
         </tbody>
     </table>
-</div>
+    <x-ui.button wire="openDrillModal" class="block mx-auto my-4">モーダルオープン</x-ui.button>
+
+    @if($drillModal)
+    <div>
+        モーダルテスト
+        <x-ui.button wire="closeDrillModal" class="block mx-auto my-4">モーダルクローズ</x-ui.button>
+    </div>
+    @endif
+</section>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -26,7 +26,7 @@
     <x-ui.modal-container wire="closeDrillModal" id="drill">
         <x-form.livewire-form-container
             title="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}" buttonTitle="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}"
-            submitWire="drillStore" closeWire="closeDrillModal">
+            submitWire="{{ $editingDrillId ? 'drillUpdate' : 'drillStore' }}" closeWire="closeDrillModal">
             <x-form.input name="question">問題</x-form.input>
             <x-form.input name="choice_1">解答.1</x-form.input>
             <x-form.input name="choice_2">解答.2</x-form.input>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -20,7 +20,7 @@
             @endforeach
         </tbody>
     </table>
-    <x-ui.button wire="openDrillModal" class="block mx-auto my-4">モーダルオープン</x-ui.button>
+    <x-ui.button wire="openDrillModal" class="block mx-auto my-4 rounded">問題の追加</x-ui.button>
 
     @if($drillModal)
     <x-ui.modal-container wire="closeDrillModal" id="drill">
@@ -32,7 +32,9 @@
             <x-form.input name="choice_2">解答.2</x-form.input>
             <x-form.input name="choice_3">解答.3</x-form.input>
             <x-form.input name="choice_4">解答.4</x-form.input>
-            <x-form.input name="correct_choice">答え</x-form.input>
+            <x-form.select name="correct_choice" :options="[1 => 1, 2 => 2, 3 => 3, 4 => 4]">
+                答え
+            </x-form.select>
             <x-form.textarea name="explanations">解説</x-form.textarea>
         </x-form.livewire-form-container>
     </x-ui.modal-container>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -1,0 +1,23 @@
+<div>
+    <h2 class="mb-6 text-2xl font-semibold">{{ $lessonTitle }}の詳細</h2>
+    <table class="table-auto w-full text-left">
+        <thead>
+            <tr>
+                <th class="px-4 py-3 font-semibold bg-gray-100">No.</th>
+                <th class="px-4 py-3 font-semibold bg-gray-100">問題</th>
+                <th class="px-4 py-3 font-semibold bg-gray-100">登録日</th>
+                <th class="px-4 py-3 font-semibold bg-gray-100">編集</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($drills as $drill)
+            <tr>
+                <td class="px-4 py-3 border-t-2 border-gray-200">{{ $drill->id }}</td>
+                <td class="px-4 py-3 border-t-2 border-gray-200">{{ $drill->question }}</td>
+                <td class="px-4 py-3 border-t-2 border-gray-200">{{ $drill->created_at }}</td>
+                <td class="px-4 py-3 border-t-2 border-gray-200">編集</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -26,7 +26,7 @@
     <x-ui.modal-container wire="closeDrillModal" id="drill">
         <x-form.livewire-form-container
             title="ドリルの作成" buttonTitle="作成"
-            closeWire="closeDrillModal">
+            submitWire="drillStore" closeWire="closeDrillModal">
             <x-form.input name="question">問題</x-form.input>
             <x-form.input name="choice_1">解答.1</x-form.input>
             <x-form.input name="choice_2">解答.2</x-form.input>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -15,7 +15,7 @@
                 <td class="px-4 py-3 border-t-2 border-gray-200">{{ $drill->id }}</td>
                 <td class="px-4 py-3 border-t-2 border-gray-200">{{ $drill->question }}</td>
                 <td class="px-4 py-3 border-t-2 border-gray-200">{{ $drill->created_at }}</td>
-                <td class="px-4 py-3 border-t-2 border-gray-200">編集</td>
+                <td class="px-4 py-3 border-t-2 text-sky-500 hover:text-sky-700 border-gray-200 cursor-pointer" wire:click="openEditDrillModal({{ $drill->id }})">編集</td>
             </tr>
             @endforeach
         </tbody>
@@ -25,7 +25,7 @@
     @if($drillModal)
     <x-ui.modal-container wire="closeDrillModal" id="drill">
         <x-form.livewire-form-container
-            title="ドリルの作成" buttonTitle="作成"
+            title="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}" buttonTitle="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}"
             submitWire="drillStore" closeWire="closeDrillModal">
             <x-form.input name="question">問題</x-form.input>
             <x-form.input name="choice_1">解答.1</x-form.input>

--- a/resources/views/livewire/lesson-index.blade.php
+++ b/resources/views/livewire/lesson-index.blade.php
@@ -8,6 +8,7 @@
                 <th class="px-4 py-3 font-semibold bg-gray-100">登録日</th>
                 <th class="px-4 py-3 font-semibold bg-gray-100">学ぶ</th>
                 <th class="px-4 py-3 font-semibold bg-gray-100">編集</th>
+                <th class="px-4 py-3 font-semibold bg-gray-100">詳細</th>
             </tr>
         </thead>
         <tbody>
@@ -18,6 +19,7 @@
                 <td class="px-4 py-3 border-t-2 border-gray-200">{{ $lesson->created_at }}</td>
                 <td class="px-4 py-3 border-t-2 border-gray-200">開始</td>
                 <td class="px-4 py-3 border-t-2 text-sky-500 hover:text-sky-700 border-gray-200 cursor-pointer" wire:click="openEditLessonModal({{ $lesson->id }})">編集</td>
+                <td class="px-4 py-3 border-t-2  border-gray-200"><a href="{{ route('drills', ['lesson_id' => $lesson->id]) }}" class="text-sky-500 hover:text-sky-700">詳細</a></td>
             </tr>
             @endforeach
         </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,8 +8,12 @@ Route::view('dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
 
+Route::get('dashboard/{lesson_id}', function ($lesson_id) {
+    return view('drills', ['lesson_id' => $lesson_id]);
+})->middleware(['auth', 'verified'])->name('drills');
+
 Route::view('profile', 'profile')
     ->middleware(['auth'])
     ->name('profile');
 
-require __DIR__.'/auth.php';
+require __DIR__ . '/auth.php';


### PR DESCRIPTION
# DrillのCRUD機能の追加
- drillの一覧を表示するルートの作成
- 問題の一覧表示を作成
- 問題の追加機能drillStoreを実装
- drillUpdateを作成しdrillの編集機能の追加
- drillDestroyを作成しdrillの削除機能の追加

DrillのCRUDができるように機能の追加。
全て一枚ページでモーダルを利用して、フォームが出現するようにしている。（Lessonと同じ仕様）

## モーダルの作成
- モーダルの開閉処理を追加
- openEditDrillModalを作成し編集モーダルの開閉を追加
- formの内容をリセットするresetDrillFormを作成

モーダルを閉じたタイミングでresetDrillFormが実行され、form内の内容はリセットされるようにしている。
