### PR TITLE
削除時に削除確認モーダルを表示（drill / lesson）

### DIFF
--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -13,6 +13,7 @@ class DrillIndex extends Component
     public $drills;
     public $lessonTitle;
     public $drillModal = false;
+    public $deleteDrillModal = false;
     public $lesson_id, $editingDrillId, $question, $choice_1, $choice_2, $choice_3, $choice_4, $correct_choice, $explanations;
 
     public function mount($lesson_id)
@@ -43,6 +44,16 @@ class DrillIndex extends Component
         $this->explanations = $drill->explanations;
 
         $this->drillModal = true;
+    }
+
+    public function openDeleteDrillModal()
+    {
+        $this->deleteDrillModal = true;
+    }
+
+    public function closeDeleteDrillModal()
+    {
+        $this->deleteDrillModal = false;
     }
 
     public function closeDrillModal()

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -51,15 +51,15 @@ class DrillIndex extends Component
         $this->deleteDrillModal = true;
     }
 
-    public function closeDeleteDrillModal()
-    {
-        $this->deleteDrillModal = false;
-    }
-
     public function closeDrillModal()
     {
         $this->drillModal = false;
         $this->resetDrillForm();
+    }
+
+    public function closeDeleteDrillModal()
+    {
+        $this->deleteDrillModal = false;
     }
 
     public function drillStore()
@@ -105,6 +105,7 @@ class DrillIndex extends Component
         $drill->delete();
 
         $this->getDrills();
+        $this->closeDeleteDrillModal();
         $this->closeDrillModal();
     }
 

--- a/app/Livewire/LessonIndex.php
+++ b/app/Livewire/LessonIndex.php
@@ -13,6 +13,7 @@ class LessonIndex extends Component
     public $title;
     public $lessons;
     public $lessonModal = false;
+    public $deleteLessonModal = false;
 
     public function mount()
     {
@@ -34,10 +35,20 @@ class LessonIndex extends Component
         $this->lessonModal = true;
     }
 
+    public function openDeleteLessonModal()
+    {
+        $this->deleteLessonModal = true;
+    }
+
     public function closeLessonModal()
     {
         $this->lessonModal = false;
         $this->resetLessonForm();
+    }
+
+    public function closeDeleteLessonModal()
+    {
+        $this->deleteLessonModal = false;
     }
 
     public function lessonStore()
@@ -58,10 +69,9 @@ class LessonIndex extends Component
         $lesson->update([
             'title' => $this->title,
         ]);
-    
+
         $this->closeLessonModal();
         $this->getLessons();
-
     }
 
     public function lessonDestroy()
@@ -70,6 +80,8 @@ class LessonIndex extends Component
         $lesson->delete();
 
         $this->getLessons();
+
+        $this->closeDeleteLessonModal();
         $this->closeLessonModal();
     }
 

--- a/resources/views/components/form/livewire-form-container.blade.php
+++ b/resources/views/components/form/livewire-form-container.blade.php
@@ -3,7 +3,6 @@
     'buttonTitle' => "送信",
     'submitWire' => null,
     'closeWire' => null,
-    'deleteWire' => null,
 ])
 
 <form wire:submit.prevent="{{ $submitWire }}"
@@ -14,10 +13,10 @@
         <x-ui.button size="normal" color="blue" class="mt-8 block mx-auto rounded">{{ $buttonTitle }}</x-ui.button>
         <x-ui.button type="button" size="normal" color="gray" wire="{{ $closeWire }}" class="block mx-auto rounded">閉じる</x-ui.button>
     </div>
-    @if ($deleteWire)
-    <div class="mt-6 pt-2 border-t border-dashed border-gray-300">
-        <x-ui.button type="button" wire="{{ $deleteWire }}" color="red" class="block mx-auto rounded">削除</x-ui.button>
-    </div>
-    @endif
 
+    @if (isset($deleteSlot))
+        <div class="mt-6 pt-2 border-t border-dashed border-gray-300">
+        {{ $deleteSlot }}
+        </div>
+    @endif
 </form>

--- a/resources/views/components/ui/delete-modal-container.blade.php
+++ b/resources/views/components/ui/delete-modal-container.blade.php
@@ -1,0 +1,16 @@
+@props([
+    'maxWidth' => 'max-w-[580px]',
+    'id' => 'deleteModal',
+    'title',
+    'closeWire' => null,
+    'deleteWire' => null,
+])
+
+<x-ui.modal-container wire="{{ $closeWire }}" id="{{ $id }}" class="text-center">
+    <p class="my-4 font-semibold text-lg">「{{$title}}」</p>
+    <p>を削除しますか？</p>
+    <div class="flex justify-center items-center my-4">
+        <x-ui.button type="button" size="normal" color="gray" wire="{{ $closeWire }}" class="mx-6 rounded">キャンセル</x-ui.button>
+        <x-ui.button type="button" wire="{{ $deleteWire }}" color="red" class="mx-6 rounded">削除</x-ui.button>
+    </div>
+</x-ui.modal-container>

--- a/resources/views/livewire/drill-index.blade.php
+++ b/resources/views/livewire/drill-index.blade.php
@@ -26,7 +26,7 @@
     <x-ui.modal-container wire="closeDrillModal" id="drill">
         <x-form.livewire-form-container
             title="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}" buttonTitle="{{ $editingDrillId ? '問題の編集' : '問題の作成' }}"
-            submitWire="{{ $editingDrillId ? 'drillUpdate' : 'drillStore' }}" closeWire="closeDrillModal" deleteWire="{{ $editingDrillId ? 'drillDestroy' : null }}">
+            submitWire="{{ $editingDrillId ? 'drillUpdate' : 'drillStore' }}" closeWire="closeDrillModal">
             <x-form.input name="question">問題</x-form.input>
             <x-form.input name="choice_1">解答.1</x-form.input>
             <x-form.input name="choice_2">解答.2</x-form.input>
@@ -36,6 +36,16 @@
                 答え
             </x-form.select>
             <x-form.textarea name="explanations">解説</x-form.textarea>
+
+            @if(isset($editingDrillId))
+            <x-slot name="deleteSlot">
+                <x-ui.button type="button" color="red" wire="openDeleteDrillModal" class="block mx-auto my-4 rounded">削除</x-ui.button>
+                @if($deleteDrillModal)
+                <x-ui.delete-modal-container title="{{ $question }}" closeWire="closeDeleteDrillModal" deleteWire="drillDestroy" />
+                @endif
+            </x-slot>
+            @endif
+
         </x-form.livewire-form-container>
     </x-ui.modal-container>
     @endif

--- a/resources/views/livewire/lesson-index.blade.php
+++ b/resources/views/livewire/lesson-index.blade.php
@@ -30,10 +30,19 @@
     <x-ui.modal-container wire="closeLessonModal" id="lesson">
         <x-form.livewire-form-container
             title="{{ $editingLessonId ? 'レッスンの編集' : 'レッスンの作成' }}" buttonTitle="{{ $editingLessonId ? '編集' : '作成' }}"
-            submitWire="{{ $editingLessonId ? 'lessonUpdate' : 'lessonStore' }}" closeWire="closeLessonModal" deleteWire="{{ $editingLessonId ? 'lessonDestroy' : null }}">
+            submitWire="{{ $editingLessonId ? 'lessonUpdate' : 'lessonStore' }}" closeWire="closeLessonModal">
             <x-form.input name="title">レッスン名</x-form.input>
+
+            @if(isset($editingLessonId))
+            <x-slot name="deleteSlot">
+                <x-ui.button type="button" color="red" wire="openDeleteLessonModal" class="block mx-auto my-4 rounded">削除</x-ui.button>
+                @if($deleteLessonModal)
+                <x-ui.delete-modal-container title="{{ $lesson->title }}" closeWire="closeDeleteLessonModal" deleteWire="lessonDestroy" />
+                @endif
+            </x-slot>
+            @endif
+
         </x-form.livewire-form-container>
     </x-ui.modal-container>
     @endif
-
 </section>


### PR DESCRIPTION
# 削除時に確認のメッセージをモーダル表示

- drillの削除時に削除確認のモーダルが表示されるよう変更
- lessonの削除時に削除確認のモーダルが表示されるよう変更

今までは削除ボタンをクリックで削除が実行されていた。
削除ボタンクリックで確認の為、削除モーダルが表示される使用に変更。
これにより誤操作により削除してしまうのを防ぎやすくしている。

## コンポーネントの変更

- delete-modal-containerコンポーネントを作成
- livewire-form-containerの削除部分をslotに変更

仕様変更に伴い、既存のコンポーネントを変更している。

