### PR TITLE
フォームバリデーションの追加 (lesson / drill)

### DIFF
--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -15,7 +15,7 @@ class DrillIndex extends Component
     public $lessonTitle;
     public $drillModal = false;
     public $deleteDrillModal = false;
-    public $lesson_id, $editingDrillId, $question, $choice_1, $choice_2, $choice_3, $choice_4, $correct_choice, $explanations;
+    public $lesson_id, $editingDrillId, $question, $choice_1, $choice_2, $choice_3, $choice_4, $correct_choice = "1", $explanations;
 
     public function mount($lesson_id)
     {

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use App\Models\Drill;
 use App\Models\Lesson;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
 use Livewire\Component;
 
 class DrillIndex extends Component
@@ -64,18 +65,9 @@ class DrillIndex extends Component
 
     public function drillStore()
     {
-        Drill::create([
-            'user_id' => $this->user_id,
-            'lesson_id' => $this->lesson_id,
-            'question' => $this->question,
-            'choice_1' => $this->choice_1,
-            'choice_2' => $this->choice_2,
-            'choice_3' => $this->choice_3,
-            'choice_4' => $this->choice_4,
-            'correct_choice' => $this->correct_choice,
-            'explanations' => $this->explanations,
+        $validated = $this->validateDrill();
 
-        ]);
+        Drill::create($validated);
 
         $this->getDrills();
         $this->closeDrillModal();
@@ -84,16 +76,9 @@ class DrillIndex extends Component
     public function drillUpdate()
     {
         $drill = Drill::findOrFail($this->editingDrillId);
+        $validated = $this->validateDrill();
 
-        $drill->update([
-            'question' => $this->question,
-            'choice_1' => $this->choice_1,
-            'choice_2' => $this->choice_2,
-            'choice_3' => $this->choice_3,
-            'choice_4' => $this->choice_4,
-            'correct_choice' => $this->correct_choice,
-            'explanations' => $this->explanations,
-        ]);
+        $drill->update($validated);
 
         $this->getDrills();
         $this->closeDrillModal();
@@ -121,7 +106,64 @@ class DrillIndex extends Component
 
     public function resetDrillForm()
     {
-        $this->reset(['editingDrillId', 'question', 'choice_1', 'choice_2', 'choice_3', 'choice_4', 'correct_choice', 'explanations']);
+        $this->reset([
+            'editingDrillId',
+            'question',
+            'choice_1',
+            'choice_2',
+            'choice_3',
+            'choice_4',
+            'correct_choice',
+            'explanations'
+        ]);
+    }
+
+    public function rules()
+    {
+        return [
+            'user_id' => 'required|exists:users,id',
+            'lesson_id' => 'required|exists:lessons,id',
+            'question' => 'required|string',
+            'choice_1' => 'required|string|max:50',
+            'choice_2' => 'required|string|max:50',
+            'choice_3' => 'required|string|max:50',
+            'choice_4' => 'required|string|max:50',
+            'correct_choice' => 'required|integer|between:1,4',
+            'explanations' => 'nullable|string',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'question' => '問題',
+            'choice_1' => '解答.1',
+            'choice_2' => '解答.2',
+            'choice_3' => '解答.3',
+            'choice_4' => '解答.4',
+            'correct_choice' => '答え',
+            'explanations' => '解説',
+        ];
+    }
+
+    protected function validateDrill()
+    {
+        return Validator::make(
+            $this->only([
+                'user_id',
+                'lesson_id',
+                'question',
+                'choice_1',
+                'choice_2',
+                'choice_3',
+                'choice_4',
+                'correct_choice',
+                'explanations'
+            ]),
+            $this->rules(),
+            [],
+            $this->attributes()
+        )->validate();
     }
 
     public function render()

--- a/app/Livewire/DrillIndex.php
+++ b/app/Livewire/DrillIndex.php
@@ -55,6 +55,7 @@ class DrillIndex extends Component
     public function closeDrillModal()
     {
         $this->drillModal = false;
+        $this->resetErrorBag();
         $this->resetDrillForm();
     }
 

--- a/app/Livewire/LessonIndex.php
+++ b/app/Livewire/LessonIndex.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\Models\Lesson;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
 use Livewire\Component;
 
 class LessonIndex extends Component
@@ -53,10 +54,9 @@ class LessonIndex extends Component
 
     public function lessonStore()
     {
-        Lesson::create([
-            'user_id' => $this->user_id,
-            'title' => $this->title,
-        ]);
+        $validated = $this->validateLesson();
+
+        Lesson::create($validated);
 
         $this->getLessons();
         $this->closeLessonModal();
@@ -65,10 +65,10 @@ class LessonIndex extends Component
     public function lessonUpdate()
     {
         $lesson = Lesson::findOrFail($this->editingLessonId);
+        
+        $validated = $this->validateLesson();
 
-        $lesson->update([
-            'title' => $this->title,
-        ]);
+        $lesson->update($validated);
 
         $this->closeLessonModal();
         $this->getLessons();
@@ -93,6 +93,31 @@ class LessonIndex extends Component
     public function resetLessonForm()
     {
         $this->reset(['editingLessonId', 'title']);
+    }
+
+    public function rules()
+    {
+        return [
+            'user_id' => 'required|exists:users,id',
+            'title' => 'required|string|min:2|max:25',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'title' => 'レッスン名',
+        ];
+    }
+
+    protected function validateLesson()
+    {
+        return Validator::make(
+            $this->only(['user_id', 'title']),
+            $this->rules(),
+            [],
+            $this->attributes()
+        )->validate();
     }
 
     public function render()

--- a/app/Livewire/LessonIndex.php
+++ b/app/Livewire/LessonIndex.php
@@ -44,6 +44,7 @@ class LessonIndex extends Component
     public function closeLessonModal()
     {
         $this->lessonModal = false;
+        $this->resetErrorBag();
         $this->resetLessonForm();
     }
 
@@ -65,7 +66,7 @@ class LessonIndex extends Component
     public function lessonUpdate()
     {
         $lesson = Lesson::findOrFail($this->editingLessonId);
-        
+
         $validated = $this->validateLesson();
 
         $lesson->update($validated);

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -9,10 +9,13 @@
     <label for="{{ $name }}" class="leading-7 text-sm text-gray-600">{{ $slot }}</label>
     <select id="{{ $name }}" name="{{ $name }}" wire:model="{{ $name }}"
         class="{{ $maxWidth }} border rounded border-gray-300 bg-gray-50 focus:bg-white transition-colors duration-200 ease-in-out">
-        @foreach ($options as $value => $label)
-        <option value="{{ $value }}" {{ old($name, $selected) == $value ? 'selected' : '' }}>
-            {{ $label }}
+        <option value="" disabled {{ old($name, $selected) === null || old($name, $selected) === '' ? 'selected' : '' }}>
+            選択してください
         </option>
+        @foreach ($options as $value => $label)
+            <option value="{{ $value }}" {{ old($name, $selected) == $value ? 'selected' : '' }}>
+                {{ $label }}
+            </option>
         @endforeach
     </select>
 </div>


### PR DESCRIPTION
## フォームバリデーションの追加

- レッスンのstoreとupdateにバリデーションを追加
- 問題のstoreとupdateにバリデーションを追加
- モーダルを閉じた時にバリデーションエラーをリセットするよう変更

「レッスンと問題」の「追加と編集」の際に、バリデーションが行われるよう機能追加。
共に、モーダルを閉じた時にバリデーションエラーがリセットされるようにしている。
