### PR TITLE
フラッシュカードで学ぶの部分を作成

### DIFF
--- a/app/Livewire/LessonFlashcard.php
+++ b/app/Livewire/LessonFlashcard.php
@@ -2,7 +2,6 @@
 
 namespace App\Livewire;
 
-use App\Models\Drill;
 use App\Models\Lesson;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
@@ -18,6 +17,7 @@ class LessonFlashcard extends Component
 
     public $answerCard = false;
 
+    public $cancelModal = false;
     public $endModal = false;
 
 
@@ -41,6 +41,11 @@ class LessonFlashcard extends Component
 
     public function nextQuestion()
     {
+        if ($this->currentIndex >= count($this->drills) - 1) {
+            $this->endModal = true;
+            return;
+        }
+
         $this->currentIndex++;
         $this->answerCard = false;
     }
@@ -53,12 +58,12 @@ class LessonFlashcard extends Component
 
     public function openEndModal()
     {
-        $this->endModal = true;
+        $this->cancelModal = true;
     }
 
     public function closeEndModal()
     {
-        $this->endModal = false;
+        $this->cancelModal = false;
     }
 
     public function getLesson($lesson_id)

--- a/app/Livewire/LessonFlashcard.php
+++ b/app/Livewire/LessonFlashcard.php
@@ -2,10 +2,34 @@
 
 namespace App\Livewire;
 
+use App\Models\Drill;
+use App\Models\Lesson;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 class LessonFlashcard extends Component
 {
+    public $user_id;
+    public $lesson_id;
+    public $lesson;
+
+    public $drills = [];
+    public $currentIndex = 0;
+
+    public function mount($lesson_id)
+    {
+        $this->user_id = Auth::id();
+        $this->lesson_id = $lesson_id;
+
+        $this->getLesson($lesson_id);
+    }
+
+    public function getLesson($lesson_id)
+    {
+        $this->lesson = Lesson::where('id', $lesson_id)->with('drills')->first();
+        $this->drills = $this->lesson->drills->values();
+    }
+
     public function render()
     {
         return view('livewire.lesson-flashcard');

--- a/app/Livewire/LessonFlashcard.php
+++ b/app/Livewire/LessonFlashcard.php
@@ -16,12 +16,24 @@ class LessonFlashcard extends Component
     public $drills = [];
     public $currentIndex = 0;
 
+    public $answerCard = false;
+
     public function mount($lesson_id)
     {
         $this->user_id = Auth::id();
         $this->lesson_id = $lesson_id;
 
         $this->getLesson($lesson_id);
+    }
+
+    public function openQuestion()
+    {
+        $this->answerCard = false;
+    }
+
+    public function openAnswer()
+    {
+        $this->answerCard = true;
     }
 
     public function getLesson($lesson_id)

--- a/app/Livewire/LessonFlashcard.php
+++ b/app/Livewire/LessonFlashcard.php
@@ -18,6 +18,9 @@ class LessonFlashcard extends Component
 
     public $answerCard = false;
 
+    public $endModal = false;
+
+
     public function mount($lesson_id)
     {
         $this->user_id = Auth::id();
@@ -46,6 +49,16 @@ class LessonFlashcard extends Component
     {
         $this->currentIndex--;
         $this->answerCard = true;
+    }
+
+    public function openEndModal()
+    {
+        $this->endModal = true;
+    }
+
+    public function closeEndModal()
+    {
+        $this->endModal = false;
     }
 
     public function getLesson($lesson_id)

--- a/app/Livewire/LessonFlashcard.php
+++ b/app/Livewire/LessonFlashcard.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class LessonFlashcard extends Component
+{
+    public function render()
+    {
+        return view('livewire.lesson-flashcard');
+    }
+}

--- a/app/Livewire/LessonFlashcard.php
+++ b/app/Livewire/LessonFlashcard.php
@@ -36,6 +36,18 @@ class LessonFlashcard extends Component
         $this->answerCard = true;
     }
 
+    public function nextQuestion()
+    {
+        $this->currentIndex++;
+        $this->answerCard = false;
+    }
+
+    public function backQuestion()
+    {
+        $this->currentIndex--;
+        $this->answerCard = true;
+    }
+
     public function getLesson($lesson_id)
     {
         $this->lesson = Lesson::where('id', $lesson_id)->with('drills')->first();

--- a/resources/views/flashcard.blade.php
+++ b/resources/views/flashcard.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            暗記カードの開始
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <livewire:lesson-flashcard :lesson_id="$lesson_id" />
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -1,0 +1,3 @@
+<div>
+    test
+</div>

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -24,10 +24,12 @@
 
         </div>
 
-        <div class="my-2">
-            <x-ui.button class="mx-6 rounded" color="blue"
+        <div class="my-2 flex flex-col md:flex-row ">
+            <x-ui.button class="mx-2 rounded" color="blue"
                 wire="{{ $answerCard ? 'openQuestion' : 'backQuestion' }}">⬅ 戻る</x-ui.button>
-            <x-ui.button class="mx-6 rounded"
+            <x-ui.button-link class="mx-2 rounded" color="green"
+                route="{{ route('dashboard') }}">終了</x-ui.button-link>
+            <x-ui.button class="mx-2 rounded"
                 wire="{{ $answerCard ? 'nextQuestion' : 'openAnswer'}}">次へ ➡</x-ui.button>
         </div>
     </div>

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -24,10 +24,12 @@
 
         </div>
 
-<div class="my-2">
-    <x-ui.button class="mx-6 rounded" color="blue" wire="openQuestion">⬅ 戻る</x-ui.button>
-    <x-ui.button class="mx-6 rounded" wire="openAnswer">次へ ➡</x-ui.button>
-</div>
+        <div class="my-2">
+            <x-ui.button class="mx-6 rounded" color="blue"
+                wire="{{ $answerCard ? 'openQuestion' : 'backQuestion' }}">⬅ 戻る</x-ui.button>
+            <x-ui.button class="mx-6 rounded"
+                wire="{{ $answerCard ? 'nextQuestion' : 'openAnswer'}}">次へ ➡</x-ui.button>
+        </div>
     </div>
 
 

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -27,13 +27,22 @@
         <div class="my-2 flex flex-col md:flex-row ">
             <x-ui.button class="mx-2 rounded" color="blue"
                 wire="{{ $answerCard ? 'openQuestion' : 'backQuestion' }}">⬅ 戻る</x-ui.button>
-            <x-ui.button-link class="mx-2 rounded" color="green"
-                route="{{ route('dashboard') }}">終了</x-ui.button-link>
+            <x-ui.button class="mx-2 rounded" color="green"
+                wire="openEndModal">終了</x-ui.button>
             <x-ui.button class="mx-2 rounded"
                 wire="{{ $answerCard ? 'nextQuestion' : 'openAnswer'}}">次へ ➡</x-ui.button>
         </div>
     </div>
 
-
+    @if ($endModal)
+    <x-ui.modal-container wire="closeEndModal" id="end-Modal" class="text-xl text-center font-semibold">
+        <p class="mb-6">終了するとレッスンの一覧画面へ戻ります。</p>
+        <p class="mb-6">次回開始時は最初からとなります。</p>
+        <x-ui.button class="mx-2 rounded" color="gray"
+            wire="closeEndModal">キャンセル</x-ui.button>
+        <x-ui.button-link class="mx-2 rounded" color="red"
+            route="{{ route('dashboard') }}">終了</x-ui.button-link>
+    </x-ui.modal-container>
+    @endif
 
 </section>

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -3,10 +3,33 @@
     $drill = $drills[$currentIndex];
     @endphp
 
-    <div class="flex fixed inset-0 items-center justify-center w-full h-full bg-gray-700 bg-opacity-50 z-50">
-        <div class="flex items-center justify-center w-full max-w-[600px] min-h-[250px] mx-2 p-6 shadow-lg scroll-y-auto overflow-auto border border-gray-400 bg-white">
-            <h2 class="my-2 text-2xl font-semibold break-words">{{ $drill->question }}</h2>
+    <div class="flex flex-col fixed inset-0 items-center justify-center w-full h-full bg-gray-700 bg-opacity-50 z-50">
+        <div class="flex items-center justify-center w-full max-w-[600px] min-h-[280px] mx-2 p-6 shadow-lg scroll-y-auto overflow-auto border border-gray-400 bg-white">
+            @if ($answerCard)
+            <div class="w-full text-lg">
+                <div class="mb-6">
+                    <h4 class="pb-2 mb-2 border-b border-dashed border-gray-700 text-green-700">✅ 答え</h4>
+                    <p class="ml-4">{{ $drill->{"choice_" . $drill->correct_choice} }}</p>
+                </div>
+                <div>
+                    <h4 class="pb-2 mb-2 border-b border-dashed border-gray-700 text-blue-700">📘 解説</h4>
+                    <p class="ml-4">{{ $drill->explanations }}</p>
+                </div>
+            </div>
+            @else
+            <div>
+                <h3 class="my-2 text-2xl font-semibold break-words">{{ $drill->question }}</h3>
+            </div>
+            @endif
+
         </div>
+
+<div class="my-2">
+    <x-ui.button class="mx-6 rounded" color="blue" wire="openQuestion">⬅ 戻る</x-ui.button>
+    <x-ui.button class="mx-6 rounded" wire="openAnswer">次へ ➡</x-ui.button>
+</div>
     </div>
-    
+
+
+
 </section>

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -1,3 +1,12 @@
-<div>
-    test
-</div>
+<section>
+    @php
+    $drill = $drills[$currentIndex];
+    @endphp
+
+    <div class="flex fixed inset-0 items-center justify-center w-full h-full bg-gray-700 bg-opacity-50 z-50">
+        <div class="flex items-center justify-center w-full max-w-[600px] min-h-[250px] mx-2 p-6 shadow-lg scroll-y-auto overflow-auto border border-gray-400 bg-white">
+            <h2 class="my-2 text-2xl font-semibold break-words">{{ $drill->question }}</h2>
+        </div>
+    </div>
+    
+</section>

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -24,12 +24,19 @@
 
         </div>
 
-        <div class="my-2 flex flex-col md:flex-row ">
-            <x-ui.button class="mx-2 rounded" color="blue"
+        <div class="my-2 grid grid-cols-1 md:grid-cols-3 gap-2">
+            @if ($currentIndex > 0 || $answerCard === true)
+            <x-ui.button class="rounded" color="blue"
                 wire="{{ $answerCard ? 'openQuestion' : 'backQuestion' }}">⬅ 戻る</x-ui.button>
-            <x-ui.button class="mx-2 rounded" color="green"
+            @else
+            <div class="invisible">
+                <x-ui.button class="rounded" color="blue">⬅ 戻る</x-ui.button>
+            </div>
+            @endif
+
+            <x-ui.button class="rounded" color="green"
                 wire="openEndModal">終了</x-ui.button>
-            <x-ui.button class="mx-2 rounded"
+            <x-ui.button class="rounded"
                 wire="{{ $answerCard ? 'nextQuestion' : 'openAnswer'}}">次へ ➡</x-ui.button>
         </div>
     </div>

--- a/resources/views/livewire/lesson-flashcard.blade.php
+++ b/resources/views/livewire/lesson-flashcard.blade.php
@@ -21,7 +21,6 @@
                 <h3 class="my-2 text-2xl font-semibold break-words">{{ $drill->question }}</h3>
             </div>
             @endif
-
         </div>
 
         <div class="my-2 grid grid-cols-1 md:grid-cols-3 gap-2">
@@ -33,7 +32,6 @@
                 <x-ui.button class="rounded" color="blue">⬅ 戻る</x-ui.button>
             </div>
             @endif
-
             <x-ui.button class="rounded" color="green"
                 wire="openEndModal">終了</x-ui.button>
             <x-ui.button class="rounded"
@@ -41,14 +39,31 @@
         </div>
     </div>
 
-    @if ($endModal)
-    <x-ui.modal-container wire="closeEndModal" id="end-Modal" class="text-xl text-center font-semibold">
+    @if ($cancelModal)
+    <x-ui.modal-container wire="closeEndModal" id="cancel-Modal" class="text-xl text-center font-semibold">
         <p class="mb-6">終了するとレッスンの一覧画面へ戻ります。</p>
         <p class="mb-6">次回開始時は最初からとなります。</p>
         <x-ui.button class="mx-2 rounded" color="gray"
             wire="closeEndModal">キャンセル</x-ui.button>
         <x-ui.button-link class="mx-2 rounded" color="red"
             route="{{ route('dashboard') }}">終了</x-ui.button-link>
+    </x-ui.modal-container>
+    @endif
+
+    @if ($endModal)
+    <x-ui.modal-container wire="closeEndModal" id="end-Modal" class="text-center">
+        <h2 class="text-2xl font-extrabold text-gray-800 text-center mb-6">
+            🎉 暗記カードの終了 🎉
+        </h2>
+        <p class="my-6 text-lg text-gray-700 text-center">
+            お疲れさまでした！これにて暗記カードは終了です
+        </p>
+        <div class="my-2">
+            <x-ui.button-link class="mx-2 rounded" color="green"
+                route="{{ route('dashboard') }}">レッスンの一覧へ</x-ui.button-link>
+            <x-ui.button-link class="mx-2 rounded" color="gray"
+                route="{{ route('flashcard', ['lesson_id' => $drill->lesson_id]) }}">最初からやり直す</x-ui.button-link>
+        </div>
     </x-ui.modal-container>
     @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,10 @@ Route::get('dashboard/{lesson_id}/learn', function ($lesson_id) {
     return view('learn', ['lesson_id' => $lesson_id]);
 })->middleware(['auth', 'verified'])->name('learn');
 
+Route::get('dashboard/{lesson_id}/flashcard', function ($lesson_id) {
+    return view('flashcard', ['lesson_id' => $lesson_id]);
+})->middleware(['auth', 'verified'])->name('flashcard');
+
 Route::view('profile', 'profile')
     ->middleware(['auth'])
     ->name('profile');


### PR DESCRIPTION
- flashcardのrouteの作成
- flashcard用のページの作成
- 最初の問題のみをmountで表示
- 戻ると次へで表と裏面の切り替えができるよう変更
- 次の問題と前の問題に移動できるよう追加
- 途中でレッスンの一覧へ戻れる終了ボタンの追加
- 途中終了時の確認メッセージをモーダルで表示
- 1つ目の問題の表面には戻るボタンを非表示に
- フラッシュカード終了時に終了の案内モーダルを表示

レッスンのデータを使い、フラッシュカードアプリを作成。
下記の流れで学習が進行をしていく。

・問題→次へ→裏面へ→次へ→次の問題の表面

戻るボタンを設置することで、上記の流れの1つ前の工程に戻ることができるようになっている。
最初の問題に関しては戻るを非表示。
最後の問題に関しては終了の案内をモーダルで表示をしている。

